### PR TITLE
Sourcemaps support added #1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,6 +15,9 @@ module.exports = function(grunt) {
     
     // Configuration to be run (and then tested).
     traceur: {
+      options: {
+        sourceMaps: true
+      },
       test: {
         files: {
           'test/tmp/': ['test/fixtures/*.js']

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ In your project's Gruntfile, add a section named `traceur` to the data object pa
 ```js
 grunt.initConfig({
   traceur: {
+      options: {
+        sourceMaps: true // default: false
+      },
       custom: {
         files:{
           'build/': ['js/**/*.js'] // dest : [source files]

--- a/test/traceur_test.js
+++ b/test/traceur_test.js
@@ -20,6 +20,9 @@
     test.ifError(value)
 */
 
+var fs = require('fs');
+var path = require('path');
+
 function getType (obj) {
   return Object.prototype.toString.call(obj)
 }
@@ -55,6 +58,15 @@ exports.traceur = {
     var msg = man.hi()
     test.equal(msg, 'I am a man and my name is ' + name, 'class and inheritance should work')
     test.done()
+  },
+
+  sourceMaps: function (test) {
+    var regex = /\.js\.map$/i;
+    var files = fs.readdirSync(path.join(__dirname, 'tmp')).filter(function (filename) {
+      return regex.test(filename);
+    });
+    test.equal(files.length, 4);
+    test.done();
   }
 
 };


### PR DESCRIPTION
I added source maps support. This is a very simple implementation. In the task options you can set `sourceMaps` to `true`. This will generate to each js file a second file with `.map` added to the end of the filename.
