### PR TITLE
Add support for passing more options to traceur

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ grunt.initConfig({
 ```
 Once the files have ben transpiled into ES3, you can minify or concat them. 
 
+### Options
+
+Any specified option will be passed through directly to traceur, thus you can specify any option that traceur supports.
+
+Some common options:
+
+* `experimental` - Turn on all experimental features
+* `blockBinding` - Turn on support for `let` and `const`
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/tasks/traceur.js
+++ b/tasks/traceur.js
@@ -22,6 +22,9 @@ module.exports = function(grunt) {
       sourceMaps: false
     });
 
+    // Pass along any defined options to traceur
+    traceur.options.setFromObject(options);
+
     this.files.forEach(function(group){
       var reporter = new traceur.util.ErrorReporter(),
           project = new traceur.semantics.symbols.Project();


### PR DESCRIPTION
I was frustrated with not being able to transpile code that used the `let` and `const` bindings, so I added the ability to pass along the options hash to traceur. The configuration for transpiling code with block bindings becomes:

``` javascript
    traceur: {
      options: {
        sourceMaps: true,
        blockBinding: true
      },
      release: {
        files: [
          { src: ['src/js/**/*.js'], dest: 'build/' }
        ]
      }
    }
```

and you should get support for all of the options defined here: https://github.com/google/traceur-compiler/blob/master/src/options.js#L246 although I can't find them documented outside of the code itself.
