### PR TITLE
Make sure that the copied files maintain the original structure.

### DIFF
--- a/tasks/traceur.js
+++ b/tasks/traceur.js
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
 
         var tree = results.get(file);
         var source = traceur.outputgeneration.TreeWriter.write(tree, traceurOptions);
-        var outputfile = group.dest + path.basename(file.name);
+        var outputfile = group.dest + file.name;
         grunt.file.write(outputfile, source);
 
         if (traceurOptions.sourceMap) {


### PR DESCRIPTION
I had the issue where the directory of files I was transpiling looked like:

```
js/
├── collections
│   └── todos.js
├── common.js
├── main.js
├── models
│   └── todo.js
├── routers
│   └── router.js
├── runtime.js
└── views
    ├── app.js
    └── todos.js
```

but the output from grunt-traceur would lose instead of maintain the structure, and come out like:

```
build/
├── app.js
├── common.js
├── main.js
├── router.js
├── runtime.js
├── todo.js
└── todos.js
```

Which I then use require.js to load in the browser, but it fails do the the changed relative paths..

Removing `path.basename` seems to fix this, but I'm unclear on what the original motivation was for adding it in the first place. Is there something I'm missing here?
