### PR TITLE
Correct homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "grunt-traceur",
   "description": "A grunt plugin for Google's Traceur-Compile, a lib to compile ES6 JavaScript into ES5 JavaScript.",
   "version": "0.2.2",
-  "homepage": "https://github.com/aaron/grunt-traceur",
+  "homepage": "https://github.com/aaronfrost/grunt-traceur",
   "author": {
     "name": "Aaron Frost",
     "email": "aaronfrost@gmail.com",


### PR DESCRIPTION
The NPM version has the homepage set as [https://github.com/aaron/grunt-traceur], but it should be [https://github.com/aaronfrost/grunt-traceur]. This PR corrects it.
