### PR TITLE
Reforked from latest, applied change.  All tests pass.

### DIFF
--- a/tasks/traceur.js
+++ b/tasks/traceur.js
@@ -37,9 +37,17 @@ function compileOne (grunt, compile, src, dest, options) {
     }
     src = src[0];
     var content = grunt.file.read(src).toString('utf8');
-    options.filename = src;
+    if (options.pathPrefix) {
+      options.filename = src.replace(options.pathPrefix, "");
+    } else {
+      options.filename = src;
+    }
+
     if (options.moduleNames) {
       options.moduleName = [path.dirname(dest), path.sep, path.basename(dest, path.extname(dest))].join('');
+      if (options.pathPrefix) {
+        options.moduleName = options.filename.replace(path.extname(src), "");
+      }
     }
     compile(content, options, function (err, result) {
       var sourceMapName, sourceMapPath;


### PR DESCRIPTION
My compiled modules were coming out as:

```
System.register(".._src/main/web/scripts/es6/module",
```

This is due to how grunt and yeoman are setup on a maven (java) project.  The location of the source js files relative to the Gruntfile is irrelevant, yet the files array that gets passed to the plugin always has this info.  This enhancement allows a user to set an additional option:

```
pathPrefix: '<%= app %>/scripts/'
```

which is simply the 'junk' that can be stripped from the start of the computed module name.
