### PR TITLE
Print out the error message when a file compile fails.

### DIFF
--- a/tasks/traceur.js
+++ b/tasks/traceur.js
@@ -97,7 +97,8 @@ module.exports = function(grunt) {
       Promise
         .all(this.files.map(function (group) {
           return compileOne(grunt, compile, group.src, group.dest, options)
-            .catch(function () {
+            .catch(function (e) {
+              grunt.log.error(e.message);
               success = false;
             });
         }))


### PR DESCRIPTION
I was running a task, when grunt stated that the task had failed, without giving a reason. It looks like you're (correctly) providing the reject function of the promise with an error object, but not actually observing the error object to report the error. This just adds the little code necessary.
