### PR TITLE
Peerdependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "es6-promise": "^1.0.0"
   },
   "peerDependencies": {
-    "grunt": "^0.4.4"
+    "grunt": "^0.4.4",
+    "traceur": "0.0.79"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
-    "grunt-contrib-nodeunit": "^0.4.1"
+    "grunt-contrib-nodeunit": "^0.4.1",
+    "traceur": "0.0.79"
   },
   "keywords": [
     "gruntplugin"

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "es6-promise": "^1.0.0",
-    "traceur": "0.0.79"
+    "es6-promise": "^1.0.0"
   },
   "peerDependencies": {
     "grunt": "^0.4.4"
@@ -52,7 +51,8 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
-    "grunt-contrib-nodeunit": "^0.4.1"
+    "grunt-contrib-nodeunit": "^0.4.1",
+    "traceur": "0.0.79"
   },
   "keywords": [
     "gruntplugin"

--- a/package.json
+++ b/package.json
@@ -47,13 +47,12 @@
   },
   "peerDependencies": {
     "grunt": "^0.4.4",
-    "traceur": "0.0.79"
+    "traceur": ">=0.0.60"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
-    "grunt-contrib-nodeunit": "^0.4.1",
-    "traceur": "0.0.79"
+    "grunt-contrib-nodeunit": "^0.4.1"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
I removed Traceur from the `dependencies` section. 

Then I moved it to the `peerDependencies` section. 

Then I added it to the `devDependencies`, so that it installs and we can run our tests. 

I created a dummy project with no dependencies. When I added `"grunt-traceur" : "git+https://github.com/aaronfrost/grunt-traceur#984bffafa79"` to the dependencies and ran `npm install` it installed the latest version of traceur (*0.0.79*), because the peerDependency version *>=0.0.61* allows it to install the latest version. Then I removed the node_modules folder, and added `"traceur": "0.0.65"` and then ran `npm install` and it installed *0.0.65*. This means that users of grunt-traceur will get the latest version of traceur, unless they explicitly specify the version that they want. 

I believe that this is what we were trying to accomplish by moving towards peerDependencies. 

@mciparelli please tell me what you think about this change. If you think agree that we should bump the version to 0.5.0, then I will re-PR with that change. Otherwise, I will re-PR with 0.4.1. Let me know what you think. 