### PR TITLE
Copyruntime

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,8 @@ module.exports = function(grunt) {
         moduleNaming: {
           stripPrefix: "test/tmp",
           addPrefix: "test/fixtures"
-        }
+        },
+        copyRuntime: "test/tmp"
         // traceur options here
       },
       test: {
@@ -38,6 +39,9 @@ module.exports = function(grunt) {
     },
     nodeunit: {
       tests: ['test/*_test.js']
+    },
+    clean: {
+      build: ["test/tmp"]
     }
 
   });
@@ -46,7 +50,11 @@ module.exports = function(grunt) {
   grunt.loadTasks('tasks');
 
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
+  grunt.loadNpmTasks('grunt-contrib-clean');
 
-  grunt.registerTask('default', ['traceur', 'nodeunit']);
+  grunt.registerTask('default', ['clean:build', 'traceur', 'nodeunit', 'clean:build']);
+
+  //Same as default, but doesn't clean at the end, so that you can see the output.
+  grunt.registerTask('test', ['clean:build', 'traceur', 'nodeunit']);
 
 };

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ grunt.initConfig({
       moduleNaming: {
         stripPrefix: "src/es6",
         addPrefix: "com/mycompany/project"
-      }
+      },
+      copyRuntime: 'src/es5'
     },
     custom: {
       files: [{
@@ -58,7 +59,7 @@ Some common options:
 
 * `experimental` - Turn on all experimental features
 * `blockBinding` - Turn on support for `let` and `const`
-* `includeRuntime` - Prepend runtime to output
+* `copyRuntime` - Copies the traceur_runtime.js to the location which you specify here
 * `moduleNames` - Generate named module (default: true)
 * `moduleNaming.stripPrefix` - Strip the specified prefix from generated module names
 * `moduleNaming.addPrefix` - Add the specified prefix to the generated module names (applied AFTER the `moduleNaming.stripPrefix` option)

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "es6-promise": "^1.0.0"
+    "es6-promise": "^1.0.0",
+    "lodash": "^2.4.1"
   },
   "peerDependencies": {
     "grunt": "^0.4.4",
@@ -52,6 +53,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
+    "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-nodeunit": "^0.4.1",
     "traceur": "0.0.79"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-traceur",
   "description": "A grunt plugin for Google's Traceur-Compile, a lib to compile ES6 JavaScript into ES5 JavaScript.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "homepage": "https://github.com/aaronfrost/grunt-traceur",
   "author": {
     "name": "Aaron Frost",


### PR DESCRIPTION
Just removed the `includeRuntime` feature. I made it so that the users will get an error when running the task, if they still have `includeRuntime` defined. It will continue, but shows them an error. I removed `includeRuntime` from the Readme. 

I added `copyRuntime` option, including updating the documentation to reflect it. The `copyRuntime` option, when specified, will force the task to copy the default traceur runtime into the specified location. This options makes it so that each of our users don't need to find out their own way of copying the runtime. We can provide it for them, if they will simply tell us where to put it. 

Also bumped the version number form `0.5.0` to `0.5.1`. 

**HOUSEKEEPING:**
Also added `grunt-contrib-clean` to clean out the `test/tmp` dir at the end of the default grunt task. I added a second task, `grunt test`, which will do the exact same default build, but won't clean the `test/tmp` dir at the end. This way you can see the output when you want to. But, the default task cleans up after itself now. 

@mciparelli when you merge this, you will want to republish to npm. PRing so that you can give it a second look to make sure that I didn't screw everything up. Thanks!