### PR TITLE
Fixed path stripping not working on Windows

### DIFF
--- a/tasks/traceur.js
+++ b/tasks/traceur.js
@@ -46,7 +46,7 @@ function compileOne (grunt, compile, src, dest, options) {
       var addPrefix = options.moduleNaming.addPrefix;
       var stripPrefix = options.moduleNaming.stripPrefix;
       if (stripPrefix) {
-        var namePrefixMatched = (stripPrefix + path.sep) ===
+        var namePrefixMatched = (stripPrefix + '/') ===
           options.sourceName.substring(0, stripPrefix.length + path.sep.length);
         if (namePrefixMatched) {
           options.sourceName =


### PR DESCRIPTION
Even though Windows' default path separator is `\`, traceur appears to use `/` uncondtionally internally (possibly for consistency with linux?). As a result, grunt-traceur's path stripping fails. It's using path.sep (which equals `\` instead of `/`) instead of matching traceur's behavior and using / or (even better) supporting both `/` and `\`.